### PR TITLE
Add chef gem to runtime dependency list.

### DIFF
--- a/librarian.gemspec
+++ b/librarian.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "aruba"
   s.add_development_dependency "webmock"
 
-  s.add_development_dependency "chef", ">= 0.10"
+  s.add_dependency "chef", ">= 0.10"
 end


### PR DESCRIPTION
It looks like the chef gem is [required](https://github.com/applicationsonline/librarian/blob/52df7a98e78b6e244d826ff7eaa0a9272bee4ddb/lib/librarian/chef/manifest.rb#L28-29) as a runtime dependency. No biggie, and easy fix!

Great project, I'm excited :)
