### PR TITLE
Add highline as an explicit dependency for knife integration.

### DIFF
--- a/lib/librarian/chef/integration/knife.rb
+++ b/lib/librarian/chef/integration/knife.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'highline'
 
 require 'librarian'
 require 'librarian/chef'

--- a/librarian.gemspec
+++ b/librarian.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webmock"
 
   s.add_dependency "chef", ">= 0.10"
+  s.add_dependency "highline"
 end


### PR DESCRIPTION
When setting up the knife integration I was initially missing my Cheffile.lock and as a result should have gotten an error message:

```
ERROR: You have an error in your config file /Users/fnichol/Projects/chef-repo/.chef/knife.rb
NameError: uninitialized constant Librarian::Chef::HighLine
  /Users/fnichol/Projects/chef-repo/.chef/knife.rb:33:in `from_file'

     # /Users/fnichol/Projects/chef-repo/.chef/knife.rb
 32: begin
 33:   require 'librarian/chef/integration/knife'
 34:   cookbook_path           Librarian::Chef.install_path,

```

When I tracked the error back to its source I found that an instance of HighLine was being initialized directly but not explicitly required since the chef gem pulls it in transitively (https://github.com/applicationsonline/librarian/blob/master/lib/librarian/chef/integration/knife.rb#L39-40).

I think in this case having a direct dependency on highline would be a good idea. The patch here cleared up the error and properly displayed "Cheffile.lock missing!".
