### PR TITLE
bugfix git source cache when referencing branches

### DIFF
--- a/lib/librarian/source/git.rb
+++ b/lib/librarian/source/git.rb
@@ -72,8 +72,13 @@ module Librarian
           repository.clone!(uri)
         end
         unless sha == repository.current_commit_hash
-          repository.fetch!(:tags => true)
+          repository.fetch!
           repository.checkout!(sha || ref)
+          begin
+            repository.merge!("origin/#{ref}") if ref
+          rescue Exception =>e
+            #calling repository.merge! fails if ref is a tag instead if a branch
+          end
           @sha ||= repository.current_commit_hash
         end
       end

--- a/lib/librarian/source/git.rb
+++ b/lib/librarian/source/git.rb
@@ -73,6 +73,7 @@ module Librarian
         end
         unless sha == repository.current_commit_hash
           repository.fetch!
+          repository.fetch!(:tags=>true)
           repository.checkout!(sha || ref)
           begin
             repository.merge!("origin/#{ref}") if ref

--- a/lib/librarian/source/git.rb
+++ b/lib/librarian/source/git.rb
@@ -72,8 +72,8 @@ module Librarian
           repository.clone!(uri)
         end
         unless sha == repository.current_commit_hash
+          repository.fetch!(:tags => true)
           repository.fetch!
-          repository.fetch!(:tags=>true)
           repository.checkout!(sha || ref)
           begin
             repository.merge!("origin/#{ref}") if ref

--- a/lib/librarian/source/git.rb
+++ b/lib/librarian/source/git.rb
@@ -74,12 +74,8 @@ module Librarian
         unless sha == repository.current_commit_hash
           repository.fetch!(:tags => true)
           repository.fetch!
-          repository.checkout!(sha || ref)
-          begin
-            repository.merge!("origin/#{ref}") if ref
-          rescue Exception =>e
-            #calling repository.merge! fails if ref is a tag instead if a branch
-          end
+          repository.merge_all_remote_branches!
+          repository.reset_hard! repository.hash_from(sha || ref)
           @sha ||= repository.current_commit_hash
         end
       end

--- a/lib/librarian/source/git/repository.rb
+++ b/lib/librarian/source/git/repository.rb
@@ -47,10 +47,16 @@ module Librarian
           end
         end
 
-        def fetch!(options = { })
+        def fetch!
           within do
-            command = "fetch"
-            command << " --tags" if options[:tags]
+            command = "remote update"
+            run!(command)
+          end
+        end
+
+        def merge!(reference)
+          within do
+            command = "merge #{reference}"
             run!(command)
           end
         end

--- a/lib/librarian/source/git/repository.rb
+++ b/lib/librarian/source/git/repository.rb
@@ -47,9 +47,10 @@ module Librarian
           end
         end
 
-        def fetch!
+        def fetch!(options = { })
           within do
-            command = "remote update"
+            command = "fetch"
+            command << " --tags" if options[:tags]
             run!(command)
           end
         end


### PR DESCRIPTION
This is a proposed bugfix for Issue #36.

When referencing a branch in the Cheffile, the way the local cache is updated is not really pulling in changes from the remote repository:

```
git fetch --tags
git checkout #{reference}
```

This patch changes the cache update procedure to:

```
git fetch --tags
git fetch
git checkout #{reference}
git merge origin/#{reference} # fails when :ref is a tag, errors are disregarded
```
