### PR TITLE
Bugfix for git cache update.

### DIFF
--- a/lib/librarian/source/git.rb
+++ b/lib/librarian/source/git.rb
@@ -83,7 +83,7 @@ module Librarian
           repository.fetch!(:tags => true)
           repository.fetch!
           repository.merge_all_remote_branches!
-          repository.reset_hard! repository.hash_from(sha || ref)
+          repository.checkout!(repository.hash_from(sha || ref), :force => true)
           @sha ||= repository.current_commit_hash
         end
       end

--- a/lib/librarian/source/git/repository.rb
+++ b/lib/librarian/source/git/repository.rb
@@ -40,17 +40,11 @@ module Librarian
           end
         end
 
-        def checkout!(reference)
+        def checkout!(reference, options ={ })
           within do
             command = "checkout #{reference}"
+            command <<  " --force" if options[:force]
             run!(command)
-          end
-        end
-
-        def reset_hard!(reference)
-          within do
-            command = "reset --hard #{reference}"
-            run!(command, false)
           end
         end
 
@@ -72,7 +66,7 @@ module Librarian
         def hash_from(reference)
           within do
             command = "rev-parse #{reference}"
-            run!(command)
+            run!(command).strip
           end
         end
 
@@ -85,7 +79,7 @@ module Librarian
 
         def merge_all_remote_branches!
           remote_branches.each do |branch|
-            checkout!(branch.slice(%r{[^/]+$}))
+            checkout!(branch.slice(%r{[^/]+$}), :force => true)
             merge! branch
           end
         end


### PR DESCRIPTION
This fixes a regression introduced by my changes for issue #37.
`git reset --hard [SHA]` works on the current checkout branch and possibly introduces new commit that make merging with origin/[branch] impossible later on.
Using `git checkout [SHA]` creates a detached HEAD that doesn't mess up the local branches
