### PR TITLE
Executable bin/git must be a file: ignore directories.

### DIFF
--- a/lib/librarian/source/git/repository.rb
+++ b/lib/librarian/source/git/repository.rb
@@ -34,7 +34,7 @@ module Librarian
               path = File.expand_path(path)
               exts.each do |ext|
                 exe = File.join(path, cmd + ext)
-                return exe if File.executable?(exe)
+                return exe if File.file?(exe) && File.executable?(exe)
               end
             end
             nil


### PR DESCRIPTION
I had an issue where I keep my git helpers in `~/bin/git/*`, librarian detected this directory as the git binary, because directories are "executable".

Added a check to see if it's a file.
