### PR TITLE
Closes issue #115

### DIFF
--- a/lib/librarian/chef/source/site.rb
+++ b/lib/librarian/chef/source/site.rb
@@ -273,9 +273,11 @@ module Librarian
             end
 
             # Cookbook files, as pulled from Opscode Community Site API, are
-            # embedded in a subdirectory of the tarball.
+            # embedded in a subdirectory of the tarball. If created by git archive they
+            # can include the subfolder `pax_global_header`, which is ignored.
             subtemps = temp.children
             subtemps.empty? and raise "The package archive was empty!"
+            subtemps.delete_if{|pth| pth.to_s[/pax_global_header/]}
             subtemps.size > 1 and raise "The package archive has too many children!"
             subtemp = subtemps.first
             debug { "Moving #{relative_path_to(subtemp)} to #{relative_path_to(path)}" }


### PR DESCRIPTION
Accommodate sources generated by `git archive --format=.tar.gz`
