### PR TITLE
Add support for the NO_PROXY environment variable 

### DIFF
--- a/lib/librarian/chef/source/site.rb
+++ b/lib/librarian/chef/source/site.rb
@@ -308,7 +308,7 @@ module Librarian
           end
 
           def http(uri)
-            environment.net_http_class.new(uri.host, uri.port)
+            environment.net_http_class(uri.host).new(uri.host, uri.port)
           end
 
           def http_get(uri)

--- a/lib/librarian/environment.rb
+++ b/lib/librarian/environment.rb
@@ -153,10 +153,22 @@ module Librarian
       end
     end
 
-    def net_http_class
-      @net_http_class ||= begin
-        p = http_proxy_uri
-        p ? Net::HTTP::Proxy(p.host, p.port, p.user, p.password) : Net::HTTP
+    def no_proxy? host
+      @no_proxy ||= (ENV['NO_PROXY'] || ENV['no_proxy'] || 'localhost, 127.0.0.1').split(/\s*,\s*/)
+      @no_proxy.each do |host_addr|
+        return true if host.match(Regexp.quote(host_addr)+'$')
+      end
+      return false
+    end
+
+    def net_http_class host 
+      if no_proxy? host
+        Net::HTTP
+      else
+        @net_http_class ||= begin
+          p = http_proxy_uri
+          p ? Net::HTTP::Proxy(p.host, p.port, p.user, p.password) : Net::HTTP
+        end
       end
     end
 


### PR DESCRIPTION
In our setup we are using an internal cookbook site api endpoint that is not reachable via the corporate proxies. Since librarian 0.0.25 the http_proxy variable gets in out way when installing cookbooks with librarian-chef. The attached pull request adds support for the no_proxy environment variable which allows a more flexible proxy configuration.
