### PR TITLE
Github source, inspired by Bundler shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ we vendored it in our repository into the `cookbooks/` directory for us.
 The `:path =>` source won't be confused with the `:git =>` source's `:path =>`
 option.
 
+Also, there is shortcut for cookbooks hosted on GitHub, so we may write:
+
+    cookbook "rvm",
+      :github => "fnichol/chef-rvm"
+
 ### How to Use
 
 Install Librarian-Chef:

--- a/lib/librarian/chef/dsl.rb
+++ b/lib/librarian/chef/dsl.rb
@@ -9,6 +9,7 @@ module Librarian
 
       source :site => Source::Site
       source :git => Source::Git
+      source :github => Source::Github
       source :path => Source::Path
     end
   end

--- a/lib/librarian/chef/source.rb
+++ b/lib/librarian/chef/source.rb
@@ -1,3 +1,4 @@
 require 'librarian/chef/source/path'
 require 'librarian/chef/source/git'
+require 'librarian/chef/source/github'
 require 'librarian/chef/source/site'

--- a/lib/librarian/chef/source/github.rb
+++ b/lib/librarian/chef/source/github.rb
@@ -1,0 +1,27 @@
+require 'librarian/chef/source/git'
+
+module Librarian
+  module Chef
+    module Source
+      class Github
+
+        class << self
+
+          def lock_name
+            Git.lock_name
+          end
+
+          def from_lock_options(environment, options)
+            Git.from_lock_options(environment, options)
+          end
+
+          def from_spec_args(environment, uri, options)
+            Git.from_spec_args(environment, "https://github.com/#{uri}", options)
+          end
+
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
Small delegate source, which allows slightly cleaner syntax for public github repositories.

Because of it's just delegate, there is no changes in lockfile when moving from git to github source and backward.
