### PR TITLE
Fix recursive copy so we can use `:path => '..'`

### DIFF
--- a/lib/librarian/chef/source/local.rb
+++ b/lib/librarian/chef/source/local.rb
@@ -36,7 +36,12 @@ module Librarian
 
         def install_perform_step_copy!(found_path, install_path)
           debug { "Copying #{relative_path_to(found_path)} to #{relative_path_to(install_path)}" }
-          FileUtils.cp_r(found_path, install_path)
+          FileUtils.mkdir_p(install_path)
+          FileUtils.cp_r(filter_path(found_path), install_path)
+        end
+
+        def filter_path(path)
+          Dir.glob("#{path}/*").reject { |e| e =~ /\/cookbooks$/ }
         end
 
         def manifest_data(name)

--- a/lib/librarian/chef/source/local.rb
+++ b/lib/librarian/chef/source/local.rb
@@ -41,7 +41,7 @@ module Librarian
         end
 
         def filter_path(path)
-          Dir.glob("#{path}/*").reject { |e| e =~ /\/cookbooks$/ }
+          Dir.glob("#{path}/*").reject { |e| e == environment.install_path.to_s }
         end
 
         def manifest_data(name)


### PR DESCRIPTION
fixes #124 by ignoring the `install_path` directory where all the resolved cookbooks go into.
