### PR TITLE
JRuby and Open3.popen3 compatibility fix

### DIFF
--- a/lib/librarian/source/git/repository.rb
+++ b/lib/librarian/source/git/repository.rb
@@ -197,10 +197,18 @@ module Librarian
         end
 
         def run_command_internal(command)
+          std = ""
+          err = ""
+          thread = nil
           Open3.popen3(*command) do |i, o, e, t|
-            raise StandardError, e.read unless (t ? t.value : $?).success?
-            o.read
+            std = o.read
+            err = e.read
+            thread = t
           end
+          
+          raise StandardError, err unless (thread ? thread.value : $?).success?
+
+          std
         end
 
         def debug(*args, &block)


### PR DESCRIPTION
JRuby doesn't set $? until after the Open3.popen3 block has finished.
Moving the error checking logic outside fixes this problem.
