### PR TITLE
shorten MD5 hexdigests from 32 to 16 chars

### DIFF
--- a/lib/librarian/chef/source/site.rb
+++ b/lib/librarian/chef/source/site.rb
@@ -281,7 +281,7 @@ module Librarian
           end
 
           def hexdigest(bytes)
-            Digest::MD5.hexdigest(bytes)
+            Digest::MD5.hexdigest(bytes)[0..15]
           end
 
           def to_uri(uri)
@@ -404,7 +404,7 @@ module Librarian
 
         def cache_path
           @cache_path ||= begin
-            dir = Digest::MD5.hexdigest(uri)
+            dir = Digest::MD5.hexdigest(uri)[0..15]
             environment.cache_path.join("source/chef/site/#{dir}")
           end
         end

--- a/lib/librarian/source/git.rb
+++ b/lib/librarian/source/git.rb
@@ -125,7 +125,7 @@ module Librarian
           path_part = "/#{path}" if path
           ref_part = "##{ref}"
           key_source = [uri_part, path_part, ref_part].join
-          Digest::MD5.hexdigest(key_source)
+          Digest::MD5.hexdigest(key_source)[0..15]
         end
       end
 


### PR DESCRIPTION
See GH-130

Reduce the probability of `Errno::ENOENT` errors when the max path length limit on windows  (256 chars) is exceeded by shortening the MD5 hashes from 32 to 16 characters.

This increases the [probability of a hash collision to 1:1 billion](http://stackoverflow.com/questions/2256423/truncating-an-md5-hash-how-do-i-calculate-the-odds-of-a-collision-occuring) but should still be good enough.

Since there are two hashes involved in the cache path for a cookbook (e.g. after this PR: `tmp/librarian/cache/source/chef/site/877777683730772c/apache2/version-uri/4c32315570baa05b/package/`) this saves us 32 chars compared to master.
