### PR TITLE
environment: Make "tmp" folder configurable via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ Configuration affects how various commands operate.
   path, it is relative to the directory containing the `Cheffile`. The
   equivalent environment variable is `LIBRARIAN_CHEF_PATH`.
 
+* The `tmp` config sets the cache directory for librarian. If a relative
+  path, it is relative to the directory containing the `Cheffile`. The
+  equivalent environment variable is `LIBRARIAN_CHEF_TMP`.
+
 * The `install.strip-dot-git` config causes the `.git/` directory to be stripped
   out when installing cookbooks from a git source. This must be set to exactly
   "1" to cause this behavior. The equivalent environment variable is

--- a/lib/librarian/environment.rb
+++ b/lib/librarian/environment.rb
@@ -93,12 +93,17 @@ module Librarian
       Resolver.new(self)
     end
 
+    def tmp_path
+      part = config_db["tmp"] || "tmp"
+      project_path.join(part)
+    end
+
     def cache_path
-      project_path.join("tmp/librarian/cache")
+      tmp_path.join("librarian/cache")
     end
 
     def scratch_path
-      project_path.join("tmp/librarian/scratch")
+      tmp_path.join("librarian/scratch")
     end
 
     def project_relative_path_to(path)


### PR DESCRIPTION
This can be used to rename the cache folder to e.g. ".tmp".

Implements issue #134
