### PR TITLE
resolution can be nil in persist_resolution if dependencies were not resolved

### DIFF
--- a/lib/librarian/action/persist_resolution_mixin.rb
+++ b/lib/librarian/action/persist_resolution_mixin.rb
@@ -8,7 +8,7 @@ module Librarian
     private
 
       def persist_resolution(resolution)
-        resolution.correct? or raise Error,
+        (resolution and resolution.correct?) or raise Error,
           "Could not resolve the dependencies."
 
         lockfile_text = lockfile.save(resolution)


### PR DESCRIPTION
If none of the dependencies can be resolved the resolution object is nil in persist_resolution. Check and print the "Could not resolve the dependencies." message

```
/Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/librarian-0.1.0/lib/librarian/action/persist_resolution_mixin.rb:11:in `persist_resolution': undefined method `correct?' for nil:NilClass (NoMethodError)
from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/librarian-0.1.0/lib/librarian/action/resolve.rb:27:in `run'
from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/librarian-0.1.0/lib/librarian/cli.rb:169:in `resolve!'
from /Users/csanchez/dev/librarian-puppet/lib/librarian/puppet/cli.rb:63:in `install'
from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/librarian-0.1.0/lib/librarian/cli.rb:26:in `block (2 levels) in bin!'
from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/librarian-0.1.0/lib/librarian/cli.rb:31:in `returning_status'
from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/librarian-0.1.0/lib/librarian/cli.rb:26:in `block in bin!'
from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/librarian-0.1.0/lib/librarian/cli.rb:47:in `with_environment'

from /Users/csanchez/.rvm/gems/ruby-1.9.3-p327/gems/librarian-0.1.0/lib/librarian/cli.rb:26:in `bin!'
from ./bin/librarian-puppet:7:in `<main>'
```
