### PR TITLE
Make Librarian::Manifest Semver 2.0.0 compatible

### DIFF
--- a/lib/librarian/manifest.rb
+++ b/lib/librarian/manifest.rb
@@ -3,13 +3,93 @@ require 'rubygems'
 module Librarian
   class Manifest
 
-    class Version
+    class PreReleaseVersion
+
+      # Compares pre-release component ids using Semver 2.0.0 spec
+      def self.compare_components(this_id,other_id)
+        case # Strings have higher precedence than numbers
+          when (this_id.is_a?(Integer) and other_id.is_a?(String))
+            -1
+          when (this_id.is_a?(String) and other_id.is_a?(Integer))
+            1
+          else
+            this_id <=> other_id
+        end
+      end
+
+      # Parses pre-release components `a.b.c` into an array ``[a,b,c]`
+      # Converts numeric components into +Integer+
+      def self.parse(prerelease)
+        if prerelease.nil?
+          []
+        else
+          prerelease.split('.').collect do |id|
+            id = Integer(id) if /^[0-9]+$/ =~ id
+            id
+          end
+        end
+      end
+
       include Comparable
+
+      attr_reader :components
+
+      def initialize(prerelease)
+        @prerelease = prerelease
+        @components = PreReleaseVersion.parse(prerelease)
+      end
+
+      def to_s
+        @prerelease
+      end
+
+      def <=>(other)
+        # null-fill zip array to prevent loss of components
+        z = Array.new([components.length,other.components.length])
+
+        # Compare each component against the other
+        comp = z.zip(components,other.components).collect do |ids|
+          case # All components being equal, the version with more of them takes precedence
+            when ids[1].nil? # Self has less elements, other wins
+              -1
+            when ids[2].nil? # Other has less elements, self wins
+              1
+            else
+              PreReleaseVersion.compare_components(ids[1],ids[2])
+          end
+        end
+        # Chose the first non-zero comparison or return 0
+        comp.delete_if {|c| c == 0}[0] || 0
+      end
+    end
+    class Version
+      @@SEMANTIC_VERSION_PATTERN = /^([0-9]+\.[0-9]+(?:\.[0-9]+)?)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
+      def self.parse_semver(version_string)
+        parsed = @@SEMANTIC_VERSION_PATTERN.match(version_string.strip)
+        if parsed
+          {
+            :full_version => parsed[0],
+            :version => parsed[1],
+            :prerelease => (PreReleaseVersion.new(parsed[2]) if parsed[2]),
+            :build => parsed[3]
+          }
+        end
+      end
+      include Comparable
+
+      attr_reader :prerelease
 
       def initialize(*args)
         args = initialize_normalize_args(args)
-
-        self.backing = Gem::Version.new(*args)
+        semver = Version.parse_semver(*args)
+        if semver
+          self.backing  = Gem::Version.new(semver[:version])
+          @prerelease   = semver[:prerelease]
+          @full_version = semver[:full_version]
+        else
+          self.backing  = Gem::Version.new(*args)
+          @full_version = to_gem_version.to_s
+        end
       end
 
       def to_gem_version
@@ -17,11 +97,25 @@ module Librarian
       end
 
       def <=>(other)
-        to_gem_version <=> other.to_gem_version
+        cmp = to_gem_version <=> other.to_gem_version
+
+        # Should compare pre-release versions?
+        if cmp == 0 and not (prerelease.nil? and other.prerelease.nil?)
+          case # Versions without prerelease take precedence
+            when (prerelease.nil? and not other.prerelease.nil?)
+              1
+            when (not prerelease.nil? and other.prerelease.nil?)
+              -1
+            else
+              prerelease <=> other.prerelease
+          end
+        else
+          cmp
+        end
       end
 
       def to_s
-        to_gem_version.to_s
+        @full_version
       end
 
       private

--- a/spec/unit/manifest_version_spec.rb
+++ b/spec/unit/manifest_version_spec.rb
@@ -1,0 +1,94 @@
+require "librarian/manifest"
+
+describe Librarian::Manifest::Version do
+
+  describe "version comparison" do
+
+    context "when version has only two components" do
+      it "creates a new version with only 2 version components" do
+        v1 = described_class.new("1.0")
+      end
+    end
+
+    context "when neither version has pre-release items" do
+      it "compares 1.0.0 < 2.0.0" do
+        v1 = described_class.new("1.0.0")
+        v2 = described_class.new("2.0.0")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 2.0.0 < 2.1.0" do
+        v1 = described_class.new("2.0.0")
+        v2 = described_class.new("2.1.0")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 2.1.0 < 2.1.1" do
+        v1 = described_class.new("2.1.0")
+        v2 = described_class.new("2.1.1")
+        expect(v1 <=> v2).to eq(-1)
+      end
+    end
+
+    context "when versions have pre-release information" do
+      it "compares 1.0.0-alpha < 1.0.0-alpha1" do
+        v1 = described_class.new("1.0.0-alpha")
+        v2 = described_class.new("1.0.0-alpha.1")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-alpha.1 < 1.0.0-alpha.beta" do
+        v1 = described_class.new("1.0.0-alpha.1")
+        v2 = described_class.new("1.0.0-alpha.beta")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-alpha.beta < 1.0.0-beta" do
+        v1 = described_class.new("1.0.0-alpha.beta")
+        v2 = described_class.new("1.0.0-beta")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-beta < 1.0.0-beta.2" do
+        v1 = described_class.new("1.0.0-beta")
+        v2 = described_class.new("1.0.0-beta.2")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-beta.2 < 1.0.0-beta.11" do
+        v1 = described_class.new("1.0.0-beta.2")
+        v2 = described_class.new("1.0.0-beta.11")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-beta.11 < 1.0.0-rc.1" do
+        v1 = described_class.new("1.0.0-beta.11")
+        v2 = described_class.new("1.0.0-rc.1")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-rc.1 < 1.0.0" do
+        v1 = described_class.new("1.0.0-rc.1")
+        v2 = described_class.new("1.0.0")
+        expect(v1 <=> v2).to eq(-1)
+      end
+    end
+
+    context "when an invalid version number is provided" do
+      it "raises" do
+        expect { described_class.new("invalidversion") }.
+            to raise_error(ArgumentError)
+      end
+    end
+
+    context "when a version is converted to string" do
+      it "should be the full semver" do
+        version = "1.0.0-beta.11+200.1.2"
+        v1 = described_class.new(version)
+        expect(v1.to_s).to eq(version)
+      end
+      it "should be the full gem version" do
+        version = "1.0.0.a"
+        v1 = described_class.new(version)
+        expect(v1.to_s).to eq(version)
+      end
+      it "should be the two-component version" do
+        version = "1.0"
+        v1 = described_class.new(version)
+        expect(v1.to_s).to eq(version)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem Summary

[Semver 2.0.0](http://semver.org/spec/v2.0.0.html) _prerelease_ section cannot be parsed by Gem::Version and causes
an exception at run-time when parsing the manifest of modules that include it.

This is causing issues in a downstream project [rodjek/librarian-puppet](https://github.com/rodjek/librarian-puppet/). I've attempted to apply [a patch](https://github.com/rodjek/librarian-puppet/pull/114) there, but it is really related this gem.  I figured it would be best to add this feature to upstream as well. I spent some extra time re-factoring it to be more readable.
## Changes
- Added [Semver 2.0.0](http://semver.org/spec/v2.0.0.html) support to Librarian::Manifest::Version
- Relaxed Semver constraints to support 2-number versions (ie: 1.0)
- Added specs to test conditions mentioned in semver spec
