### PR TITLE
Git cache key without path included

### DIFF
--- a/lib/librarian/source/git.rb
+++ b/lib/librarian/source/git.rb
@@ -122,9 +122,8 @@ module Librarian
       def cache_key
         @cache_key ||= begin
           uri_part = uri
-          path_part = "/#{path}" if path
           ref_part = "##{ref}"
-          key_source = [uri_part, path_part, ref_part].join
+          key_source = [uri_part, ref_part].join
           Digest::MD5.hexdigest(key_source)[0..15]
         end
       end

--- a/lib/librarian/version.rb
+++ b/lib/librarian/version.rb
@@ -1,3 +1,3 @@
 module Librarian
-  VERSION = "0.1.0"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
I have a git repo with many paths which was getting cached many times with librarian.  This fixes that by removing the path from the cache key.
