### PR TITLE
Update rspec to use expect syntax.  Also change == to eq and =~ to match or match_array

### DIFF
--- a/spec/functional/cli_spec.rb
+++ b/spec/functional/cli_spec.rb
@@ -15,7 +15,7 @@ module Librarian
         end
 
         it "should print the version" do
-          stdout.should == strip_heredoc(<<-STDOUT)
+          expect(stdout).to eq strip_heredoc(<<-STDOUT)
             librarian-#{Librarian::VERSION}
             librarian-mock-#{Librarian::Mock::VERSION}
           STDOUT

--- a/spec/functional/posix_spec.rb
+++ b/spec/functional/posix_spec.rb
@@ -14,19 +14,19 @@ describe Librarian::Posix do
 
     it "returns the stdout" do
       res = described_class.run!(%w[echo hello there]).strip
-      res.should be == "hello there"
+      expect(res).to eq "hello there"
     end
 
     it "changes directory" do
       tmp_path.mkpath
       res = described_class.run!(%w[pwd], :chdir => tmp_path).strip
-      res.should be == tmp_path.to_s
+      expect(res).to eq tmp_path.to_s
     end
 
     it "reads the env" do
       res = described_class.run!(%w[env], :env => {"KOALA" => "BEAR"})
       line = res.lines.find{|l| l.start_with?("KOALA=")}.strip
-      line.should be == "KOALA=BEAR"
+      expect(line).to eq "KOALA=BEAR"
     end
 
   end

--- a/spec/functional/source/git/repository_spec.rb
+++ b/spec/functional/source/git/repository_spec.rb
@@ -64,35 +64,35 @@ describe Librarian::Source::Git::Repository do
   end
 
   describe ".bin" do
-    specify { described_class.bin.should_not be_empty }
+    specify { expect(described_class.bin).to_not be_empty }
   end
 
   describe ".git_version" do
-    specify { described_class.git_version.should =~ /^\d+(\.\d+)+$/ }
+    specify { expect(described_class.git_version).to match( /^\d+(\.\d+)+$/ ) }
   end
 
   context "the original" do
     subject { described_class.new(env, git_source_path) }
 
     it "should recognize it" do
-      subject.should be_git
+      expect(subject).to be_git
     end
 
     it "should not list any remotes for it" do
-      subject.remote_names.should be_empty
+      expect(subject.remote_names).to be_empty
     end
 
     it "should not list any remote branches for it" do
-      subject.remote_branch_names.should be_empty
+      expect(subject.remote_branch_names).to be_empty
     end
 
     it "should have divergent shas for master, branch, tag, and atag" do
       revs = %W[ master #{branch} #{tag} #{atag} ]
       rev_parse = proc{|rev| git!(%W[rev-parse #{rev} --quiet]).strip}
       shas = Dir.chdir(git_source_path){revs.map(&rev_parse)}
-      shas.map(&:class).uniq.should be == [String]
-      shas.map(&:size).uniq.should be == [40]
-      shas.uniq.should be == shas
+      expect(shas.map(&:class).uniq).to eq ([String])
+      expect(shas.map(&:size).uniq).to eq ([40])
+      expect(shas.uniq).to eq shas
     end
   end
 
@@ -106,23 +106,23 @@ describe Librarian::Source::Git::Repository do
     let(:atag_sha) { subject.hash_from("origin", atag) }
 
     it "should recognize it" do
-      subject.should be_git
+      expect(subject).to be_git
     end
 
     it "should have a single remote for it" do
-      subject.should have(1).remote_names
+      expect(subject).to have(1).remote_names
     end
 
     it "should have a remote with the expected name" do
-      subject.remote_names.first.should == "origin"
+      expect(subject.remote_names.first).to eq "origin"
     end
 
     it "should have the remote branch" do
-      subject.remote_branch_names["origin"].should include branch
+      expect(subject.remote_branch_names["origin"]).to include branch
     end
 
     it "should be checked out on the master" do
-      subject.should be_checked_out(master_sha)
+      expect(subject).to be_checked_out(master_sha)
     end
 
     context "checking out the branch" do
@@ -131,11 +131,11 @@ describe Librarian::Source::Git::Repository do
       end
 
       it "should be checked out on the branch" do
-        subject.should be_checked_out(branch_sha)
+        expect(subject).to be_checked_out(branch_sha)
       end
 
       it "should not be checked out on the master" do
-        subject.should_not be_checked_out(master_sha)
+        expect(subject).to_not be_checked_out(master_sha)
       end
     end
 
@@ -145,11 +145,11 @@ describe Librarian::Source::Git::Repository do
       end
 
       it "should be checked out on the tag" do
-        subject.should be_checked_out(tag_sha)
+        expect(subject).to be_checked_out(tag_sha)
       end
 
       it "should not be checked out on the master" do
-        subject.should_not be_checked_out(master_sha)
+        expect(subject).to_not be_checked_out(master_sha)
       end
     end
 
@@ -159,11 +159,11 @@ describe Librarian::Source::Git::Repository do
       end
 
       it "should be checked out on the annotated tag" do
-        subject.should be_checked_out(atag_sha)
+        expect(subject).to be_checked_out(atag_sha)
       end
 
       it "should not be checked out on the master" do
-        subject.should_not be_checked_out(master_sha)
+        expect(subject).to_not be_checked_out(master_sha)
       end
     end
   end

--- a/spec/unit/action/base_spec.rb
+++ b/spec/unit/action/base_spec.rb
@@ -11,7 +11,7 @@ module Librarian
     it { should respond_to :environment }
 
     it "should have the environment that was assigned to it" do
-      action.environment.should be env
+      expect(action.environment).to be env
     end
 
   end

--- a/spec/unit/action/clean_spec.rb
+++ b/spec/unit/action/clean_spec.rb
@@ -30,7 +30,7 @@ module Librarian
             end
 
             it "should not try to clear the cache path" do
-              env.cache_path.should_receive(:rmtree).never
+              expect(env.cache_path).to receive(:rmtree).never
             end
           end
 
@@ -40,7 +40,7 @@ module Librarian
             end
 
             it "should try to clear the cache path" do
-              env.cache_path.should_receive(:rmtree).exactly(:once)
+              expect(env.cache_path).to receive(:rmtree).exactly(:once)
             end
           end
 
@@ -58,7 +58,7 @@ module Librarian
             end
 
             it "should not try to clear the install path" do
-              env.install_path.should_receive(:children).never
+              expect(env.install_path).to receive(:children).never
             end
           end
 
@@ -75,7 +75,7 @@ module Librarian
               env.stub_chain(:install_path, :children) { children }
 
               children.each do |child|
-                child.should_receive(:rmtree).exactly(:once)
+                expect(child).to receive(:rmtree).exactly(:once)
               end
             end
 
@@ -84,10 +84,10 @@ module Librarian
               env.stub_chain(:install_path, :children) { children }
 
               children.select(&:file?).each do |child|
-                child.should_receive(:rmtree).never
+                expect(child).to receive(:rmtree).never
               end
               children.reject(&:file?).each do |child|
-                child.should_receive(:rmtree).exactly(:once)
+                expect(child).to receive(:rmtree).exactly(:once)
               end
             end
           end

--- a/spec/unit/action/install_spec.rb
+++ b/spec/unit/action/install_spec.rb
@@ -82,13 +82,13 @@ module Librarian
           end
 
           it "should sort and install the manifests" do
-            ManifestSet.should_receive(:sort).with(manifests).exactly(:once).ordered { sorted_manifests }
+            expect(ManifestSet).to receive(:sort).with(manifests).exactly(:once).ordered { sorted_manifests }
 
             install_path.stub(:exist?) { false }
-            install_path.should_receive(:mkpath).exactly(:once).ordered
+            expect(install_path).to receive(:mkpath).exactly(:once).ordered
 
             sorted_manifests.each do |manifest|
-              manifest.should_receive(:install!).exactly(:once).ordered
+              expect(manifest).to receive(:install!).exactly(:once).ordered
             end
           end
 
@@ -97,8 +97,8 @@ module Librarian
             action.stub(:install_manifests)
 
             install_path.stub(:exist?) { true }
-            install_path.should_receive(:rmtree)
-            install_path.should_receive(:mkpath)
+            expect(install_path).to receive(:rmtree)
+            expect(install_path).to receive(:mkpath)
           end
 
         end

--- a/spec/unit/config/database_spec.rb
+++ b/spec/unit/config/database_spec.rb
@@ -52,19 +52,19 @@ describe Librarian::Config::Database do
     end
 
     it "should have the key globally" do
-      database.global[key].should == value
+      expect(database.global[key]).to eq value
     end
 
     it "should not have the key in the env" do
-      database.env[key].should be_nil
+      expect(database.env[key]).to be_nil
     end
 
     it "should not have the key locally" do
-      database.local[key].should be_nil
+      expect(database.local[key]).to be_nil
     end
 
     it "should have the key generally" do
-      database[key].should == value
+      expect(database[key]).to eq value
     end
   end
 
@@ -78,25 +78,25 @@ describe Librarian::Config::Database do
     end
 
     it "should have the key globally" do
-      database.global[key].should == value
+      expect(database.global[key]).to eq value
     end
 
     it "should not have the key in the env" do
-      database.env[key].should be_nil
+      expect(database.env[key]).to be_nil
     end
 
     it "should not have the key locally" do
-      database.local[key].should be_nil
+      expect(database.local[key]).to be_nil
     end
 
     it "should have the key generally" do
-      database[key].should == value
+      expect(database[key]).to eq value
     end
 
     it "should persist the key" do
       data = YAML.load_file(global)
 
-      data.should == {raw_key => value}
+      expect(data).to eq ({raw_key => value})
     end
   end
 
@@ -111,23 +111,23 @@ describe Librarian::Config::Database do
     end
 
     it "should not have the key globally" do
-      database.global[key].should be_nil
+      expect(database.global[key]).to be_nil
     end
 
     it "should not have the key in the env" do
-      database.env[key].should be_nil
+      expect(database.env[key]).to be_nil
     end
 
     it "should not have the key locally" do
-      database.local[key].should be_nil
+      expect(database.local[key]).to be_nil
     end
 
     it "should not have the key generally" do
-      database[key].should be_nil
+      expect(database[key]).to be_nil
     end
 
     it "should unpersist the key" do
-      File.should_not exist global
+      expect(File).to_not exist global
     end
   end
 
@@ -140,19 +140,19 @@ describe Librarian::Config::Database do
     let(:env) { {raw_key => value} }
 
     it "should not have the key globally" do
-      database.global[key].should be_nil
+      expect(database.global[key]).to be_nil
     end
 
     it "should have the key in the env" do
-      database.env[key].should == value
+      expect(database.env[key]).to eq value
     end
 
     it "should not have the key locally" do
-      database.local[key].should be_nil
+      expect(database.local[key]).to be_nil
     end
 
     it "should have the key generally" do
-      database[key].should == value
+      expect(database[key]).to eq value
     end
   end
 
@@ -166,19 +166,19 @@ describe Librarian::Config::Database do
     end
 
     it "should not have the key globally" do
-      database.global[key].should be_nil
+      expect(database.global[key]).to be_nil
     end
 
     it "should not have the key in the env" do
-      database.env[key].should be_nil
+      expect(database.env[key]).to be_nil
     end
 
     it "should have the key locally" do
-      database.local[key].should == value
+      expect(database.local[key]).to eq value
     end
 
     it "should have the key generally" do
-      database[key].should == value
+      expect(database[key]).to eq value
     end
   end
 
@@ -192,25 +192,25 @@ describe Librarian::Config::Database do
     end
 
     it "should not have the key globally" do
-      database.global[key].should be_nil
+      expect(database.global[key]).to be_nil
     end
 
     it "should not have the key in the env" do
-      database.env[key].should be_nil
+      expect(database.env[key]).to be_nil
     end
 
     it "should have the key locally" do
-      database.local[key].should == value
+      expect(database.local[key]).to eq value
     end
 
     it "should have the key generally" do
-      database[key].should == value
+      expect(database[key]).to eq value
     end
 
     it "should persist the key" do
       data = YAML.load_file(local)
 
-      data.should == {raw_key => value}
+      expect(data).to eq ({raw_key => value})
     end
   end
 
@@ -225,23 +225,23 @@ describe Librarian::Config::Database do
     end
 
     it "should not have the key globally" do
-      database.global[key].should be_nil
+      expect(database.global[key]).to be_nil
     end
 
     it "should not have the key in the env" do
-      database.env[key].should be_nil
+      expect(database.env[key]).to be_nil
     end
 
     it "should not have the key locally" do
-      database.local[key].should be_nil
+      expect(database.local[key]).to be_nil
     end
 
     it "should not have the key generally" do
-      database[key].should be_nil
+      expect(database[key]).to be_nil
     end
 
     it "should unpersist the key" do
-      File.should_not exist local
+      expect(File).to_not exist local
     end
   end
 
@@ -272,7 +272,7 @@ describe Librarian::Config::Database do
   context "project_path" do
     context "by default" do
       it "should give the default project path" do
-        database.project_path.should == Pathname("/tmp")
+        expect(database.project_path).to eq Pathname("/tmp")
       end
     end
 
@@ -280,7 +280,7 @@ describe Librarian::Config::Database do
       let(:env) { {"LIBRARIAN_GEM_GEMFILE" => "/non/sense/path/to/Sillyfile"} }
 
       it "should give the project path from the env-set specfile" do
-        database.project_path.should == Pathname("/non/sense/path/to")
+        expect(database.project_path).to eq Pathname("/non/sense/path/to")
       end
     end
   end
@@ -288,7 +288,7 @@ describe Librarian::Config::Database do
   context "specfile_path" do
     context "by default" do
       it "should give the default specfile path" do
-        database.specfile_path.should == specfile
+        expect(database.specfile_path).to eq specfile
       end
     end
 
@@ -296,7 +296,7 @@ describe Librarian::Config::Database do
       let(:env) { {"LIBRARIAN_GEM_GEMFILE" => "/non/sense/path/to/Sillyfile"} }
 
       it "should give the given specfile path" do
-        database.specfile_path.should == Pathname("/non/sense/path/to/Sillyfile")
+        expect(database.specfile_path).to eq Pathname("/non/sense/path/to/Sillyfile")
       end
     end
 
@@ -304,7 +304,7 @@ describe Librarian::Config::Database do
       let(:project_path) { "/non/sense/path/to" }
 
       it "should give the assigned specfile path" do
-        database.specfile_path.should == Pathname("/non/sense/path/to/Gemfile")
+        expect(database.specfile_path).to eq Pathname("/non/sense/path/to/Gemfile")
       end
     end
 
@@ -312,7 +312,7 @@ describe Librarian::Config::Database do
       let(:specfile_name) { "Sillyfile" }
 
       it "should give the assigned specfile path" do
-        database.specfile_path.should == Pathname("/tmp/Sillyfile")
+        expect(database.specfile_path).to eq Pathname("/tmp/Sillyfile")
       end
     end
   end

--- a/spec/unit/dependency/requirement_spec.rb
+++ b/spec/unit/dependency/requirement_spec.rb
@@ -5,8 +5,8 @@ describe Librarian::Dependency::Requirement do
   describe "#inspect" do
     subject(:requirement) { described_class.new(">= 3.2.1") }
 
-    specify { requirement.inspect.should be ==
-      "#<Librarian::Dependency::Requirement >= 3.2.1>" }
+    specify { expect(requirement.inspect).
+      to eq "#<Librarian::Dependency::Requirement >= 3.2.1>" }
   end
 
 end

--- a/spec/unit/dsl_spec.rb
+++ b/spec/unit/dsl_spec.rb
@@ -26,10 +26,10 @@ module Librarian
             dep 'dependency-1',
               :src => 'source-1'
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-1'
-          spec.sources.should be_empty
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-1'
+          expect(spec.sources).to be_empty
         end
 
         it "should run with a shortcut source" do
@@ -37,10 +37,10 @@ module Librarian
             dep 'dependency-1',
               :source => :a
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-a'
-          spec.sources.should be_empty
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-a'
+          expect(spec.sources).to be_empty
         end
 
         it "should run with a block hash source" do
@@ -49,10 +49,10 @@ module Librarian
               dep 'dependency-1'
             end
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-1'
-          spec.sources.should be_empty
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-1'
+          expect(spec.sources).to be_empty
         end
 
         it "should run with a block named source" do
@@ -61,10 +61,10 @@ module Librarian
               dep 'dependency-1'
             end
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-1'
-          spec.sources.should be_empty
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-1'
+          expect(spec.sources).to be_empty
         end
 
         it "should run with a default hash source" do
@@ -72,11 +72,11 @@ module Librarian
             source :src => 'source-1'
             dep 'dependency-1'
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-1'
-          spec.sources.should_not be_empty
-          spec.dependencies.first.source.should == spec.sources.first
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-1'
+          expect(spec.sources).to_not be_empty
+          expect(spec.dependencies.first.source).to eq spec.sources.first
         end
 
         it "should run with a default named source" do
@@ -84,11 +84,11 @@ module Librarian
             src 'source-1'
             dep 'dependency-1'
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-1'
-          spec.sources.should_not be_empty
-          spec.dependencies.first.source.should == spec.sources.first
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-1'
+          expect(spec.sources).to_not be_empty
+          expect(spec.dependencies.first.source).to eq spec.sources.first
         end
 
         it "should run with a default shortcut source" do
@@ -96,11 +96,11 @@ module Librarian
             source :a
             dep 'dependency-1'
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-a'
-          spec.sources.should_not be_empty
-          spec.dependencies.first.source.should == spec.sources.first
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-a'
+          expect(spec.sources).to_not be_empty
+          expect(spec.dependencies.first.source).to eq spec.sources.first
         end
 
         it "should run with a shortcut source hash definition" do
@@ -108,10 +108,10 @@ module Librarian
             source :b, :src => 'source-b'
             dep 'dependency-1', :source => :b
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-b'
-          spec.sources.should be_empty
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-b'
+          expect(spec.sources).to be_empty
         end
 
         it "should run with a shortcut source block definition" do
@@ -119,10 +119,10 @@ module Librarian
             source :b, proc { src 'source-b' }
             dep 'dependency-1', :source => :b
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-b'
-          spec.sources.should be_empty
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-b'
+          expect(spec.sources).to be_empty
         end
 
         it "should run with a default shortcut source hash definition" do
@@ -131,11 +131,11 @@ module Librarian
             source :b
             dep 'dependency-1'
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-b'
-          spec.sources.should_not be_empty
-          spec.sources.first.name.should == 'source-b'
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-b'
+          expect(spec.sources).to_not be_empty
+          expect(spec.sources.first.name).to eq 'source-b'
         end
 
         it "should run with a default shortcut source block definition" do
@@ -144,11 +144,11 @@ module Librarian
             source :b
             dep 'dependency-1'
           end
-          spec.dependencies.should_not be_empty
-          spec.dependencies.first.name.should == 'dependency-1'
-          spec.dependencies.first.source.name.should == 'source-b'
-          spec.sources.should_not be_empty
-          spec.sources.first.name.should == 'source-b'
+          expect(spec.dependencies).to_not be_empty
+          expect(spec.dependencies.first.name).to eq 'dependency-1'
+          expect(spec.dependencies.first.source.name).to eq 'source-b'
+          expect(spec.sources).to_not be_empty
+          expect(spec.sources.first.name).to eq 'source-b'
         end
 
       end

--- a/spec/unit/environment_spec.rb
+++ b/spec/unit/environment_spec.rb
@@ -9,15 +9,15 @@ module Librarian
     let(:env) { described_class.new }
 
     describe "#adapter_module" do
-      specify { env.adapter_module.should be nil }
+      specify { expect(env.adapter_module).to be nil }
     end
 
     describe "#adapter_name" do
-      specify { env.adapter_name.should be nil }
+      specify { expect(env.adapter_name).to be nil }
     end
 
     describe "#adapter_version" do
-      specify { env.adapter_version.should be nil }
+      specify { expect(env.adapter_version).to be nil }
     end
 
     describe "computing the home" do
@@ -27,7 +27,7 @@ module Librarian
 
         it "finds the home" do
           env.stub(:adapter_name).and_return("cat")
-          env.config_db.underlying_home.to_s.should == "/path/to/home"
+          expect(env.config_db.underlying_home.to_s).to eq "/path/to/home"
         end
       end
 
@@ -37,7 +37,7 @@ module Librarian
 
         it "finds the home" do
           env.stub(:adapter_name).and_return("cat")
-          env.config_db.underlying_home.to_s.should == real_home
+          expect(env.config_db.underlying_home.to_s).to eq real_home
         end
       end
 
@@ -49,7 +49,7 @@ module Librarian
         with_env  "http_proxy" => nil
 
         it "should have a nil http proxy uri" do
-          env.http_proxy_uri.should be_nil
+          expect(env.http_proxy_uri).to be_nil
         end
       end
 
@@ -57,19 +57,19 @@ module Librarian
         with_env  "http_proxy" => "admin:secret@example.com"
 
         it "should have the expcted http proxy uri" do
-          env.http_proxy_uri.should == URI("http://admin:secret@example.com")
+          expect(env.http_proxy_uri).to eq URI("http://admin:secret@example.com")
         end
 
         it "should have the expected host" do
-          env.http_proxy_uri.host.should == "example.com"
+          expect(env.http_proxy_uri.host).to eq "example.com"
         end
 
         it "should have the expected user" do
-          env.http_proxy_uri.user.should == "admin"
+          expect(env.http_proxy_uri.user).to eq "admin"
         end
 
         it "should have the expected password" do
-          env.http_proxy_uri.password.should == "secret"
+          expect(env.http_proxy_uri.password).to eq "secret"
         end
       end
 
@@ -79,7 +79,7 @@ module Librarian
                   "http_proxy_pass" => "secret"
 
         it "should have the expcted http proxy uri" do
-          env.http_proxy_uri.should == URI("http://admin:secret@example.com")
+          expect(env.http_proxy_uri).to eq URI("http://admin:secret@example.com")
         end
       end
 
@@ -91,11 +91,11 @@ module Librarian
         with_env  "http_proxy" => nil
 
         it "should have the normal class" do
-          env.net_http_class(proxied_host).should be Net::HTTP
+          expect(env.net_http_class(proxied_host)).to be Net::HTTP
         end
 
         it "should not be marked as a proxy class" do
-          env.net_http_class(proxied_host).should_not be_proxy_class
+          expect(env.net_http_class(proxied_host)).to_not be_proxy_class
         end
       end
 
@@ -103,18 +103,18 @@ module Librarian
         with_env  "http_proxy" => "admin:secret@example.com"
 
         it "should not by marked as a proxy class for localhost" do
-          env.net_http_class('localhost').should_not be_proxy_class
+          expect(env.net_http_class('localhost')).to_not be_proxy_class
         end
         it "should not have the normal class" do
-          env.net_http_class(proxied_host).should_not be Net::HTTP
+          expect(env.net_http_class(proxied_host)).to_not be Net::HTTP
         end
 
         it "should have a subclass the normal class" do
-          env.net_http_class(proxied_host).should < Net::HTTP
+          expect(env.net_http_class(proxied_host)).to be < Net::HTTP
         end
 
         it "should be marked as a proxy class" do
-          env.net_http_class(proxied_host).should be_proxy_class
+          expect(env.net_http_class(proxied_host)).to be_proxy_class
         end
 
         it "should have the expected proxy attributes" do
@@ -132,7 +132,7 @@ module Librarian
             "pass" => http.proxy_pass,
           }
 
-          actual_attributes.should == expected_attributes
+          expect(actual_attributes).to eq expected_attributes
         end
 
       end
@@ -145,11 +145,11 @@ module Librarian
           let(:proxied_host) { "noproxy.com" }
 
           it "should have the normal class" do
-            env.net_http_class(proxied_host).should be Net::HTTP
+            expect(env.net_http_class(proxied_host)).to be Net::HTTP
           end
 
           it "should not be marked as a proxy class" do
-            env.net_http_class(proxied_host).should_not be_proxy_class
+            expect(env.net_http_class(proxied_host)).to_not be_proxy_class
           end
         end
 
@@ -157,11 +157,11 @@ module Librarian
           let(:proxied_host) { "www.noproxy.com" }
 
           it "should have the normal class" do
-            env.net_http_class(proxied_host).should be Net::HTTP
+            expect(env.net_http_class(proxied_host)).to be Net::HTTP
           end
 
           it "should not be marked as a proxy class" do
-            env.net_http_class(proxied_host).should_not be_proxy_class
+            expect(env.net_http_class(proxied_host)).to_not be_proxy_class
           end
         end
 
@@ -169,11 +169,11 @@ module Librarian
           let(:proxied_host) { "localhost" }
 
           it "should have the normal class" do
-            env.net_http_class(proxied_host).should be Net::HTTP
+            expect(env.net_http_class(proxied_host)).to be Net::HTTP
           end
 
           it "should not be marked as a proxy class" do
-            env.net_http_class(proxied_host).should_not be_proxy_class
+            expect(env.net_http_class(proxied_host)).to_not be_proxy_class
           end
         end
 
@@ -181,11 +181,11 @@ module Librarian
           let(:proxied_host) { "127.0.0.1" }
 
           it "should have the normal class" do
-            env.net_http_class(proxied_host).should be Net::HTTP
+            expect(env.net_http_class(proxied_host)).to be Net::HTTP
           end
 
           it "should not be marked as a proxy class" do
-            env.net_http_class(proxied_host).should_not be_proxy_class
+            expect(env.net_http_class(proxied_host)).to_not be_proxy_class
           end
         end
 
@@ -193,11 +193,11 @@ module Librarian
           let(:proxied_host) { "www.example.com" }
 
           it "should have a subclass the normal class" do
-            env.net_http_class(proxied_host).should < Net::HTTP
+            expect(env.net_http_class(proxied_host)).to be < Net::HTTP
           end
 
           it "should be marked as a proxy class" do
-            env.net_http_class(proxied_host).should be_proxy_class
+            expect(env.net_http_class(proxied_host)).to be_proxy_class
           end
         end
 

--- a/spec/unit/lockfile/parser_spec.rb
+++ b/spec/unit/lockfile/parser_spec.rb
@@ -22,11 +22,11 @@ module Librarian
       end
 
       it "should give an empty list of dependencies" do
-        resolution.dependencies.should be_empty
+        expect(resolution.dependencies).to be_empty
       end
 
       it "should give an empty list of manifests" do
-        resolution.manifests.should be_empty
+        expect(resolution.manifests).to be_empty
       end
     end
 
@@ -45,56 +45,56 @@ module Librarian
       end
 
       it "should give a list of one dependency" do
-        resolution.should have(1).dependencies
+        expect(resolution).to have(1).dependencies
       end
 
       it "should give a dependency with the expected name" do
         dependency = resolution.dependencies.first
 
-        dependency.name.should == "jelly"
+        expect(dependency.name).to eq "jelly"
       end
 
       it "should give a dependency with the expected requirement" do
         dependency = resolution.dependencies.first
 
         # Note: it must be this order because this order is lexicographically sorted.
-        dependency.requirement.to_s.should == "!= 1.2.6, ~> 1.1"
+        expect(dependency.requirement.to_s).to eq "!= 1.2.6, ~> 1.1"
       end
 
       it "should give a dependency wth the expected source" do
         dependency = resolution.dependencies.first
         source = dependency.source
 
-        source.name.should == "source-a"
+        expect(source.name).to eq "source-a"
       end
 
       it "should give a list of one manifest" do
-        resolution.should have(1).manifests
+        expect(resolution).to have(1).manifests
       end
 
       it "should give a manifest with the expected name" do
         manifest = resolution.manifests.first
 
-        manifest.name.should == "jelly"
+        expect(manifest.name).to eq "jelly"
       end
 
       it "should give a manifest with the expected version" do
         manifest = resolution.manifests.first
 
-        manifest.version.to_s.should == "1.3.5"
+        expect(manifest.version.to_s).to eq "1.3.5"
       end
 
       it "should give a manifest with no dependencies" do
         manifest = resolution.manifests.first
 
-        manifest.dependencies.should be_empty
+        expect(manifest.dependencies).to be_empty
       end
 
       it "should give a manifest with the expected source" do
         manifest = resolution.manifests.first
         source = manifest.source
 
-        source.name.should == "source-a"
+        expect(source.name).to eq "source-a"
       end
 
       it "should give the dependency and the manifest the same source instance" do
@@ -104,7 +104,7 @@ module Librarian
         dependency_source = dependency.source
         manifest_source = manifest.source
 
-        manifest_source.should be dependency_source
+        expect(manifest_source).to be dependency_source
       end
     end
 
@@ -125,36 +125,36 @@ module Librarian
       end
 
       it "should give a list of one dependency" do
-        resolution.should have(1).dependencies
+        expect(resolution).to have(1).dependencies
       end
 
       it "should have the expected dependency" do
         dependency = resolution.dependencies.first
 
-        dependency.name.should == "jelly"
+        expect(dependency.name).to eq "jelly"
       end
 
       it "should give a list of all the manifests" do
-        resolution.should have(2).manifests
+        expect(resolution).to have(2).manifests
       end
 
       it "should include all the expected manifests" do
         manifests = ManifestSet.new(resolution.manifests)
 
-        manifests.to_hash.keys.should =~ %w(butter jelly)
+        expect(manifests.to_hash.keys).to match_array( %w(butter jelly) )
       end
 
       it "should have an internally consistent set of manifests" do
         manifests = ManifestSet.new(resolution.manifests)
 
-        manifests.should be_consistent
+        expect(manifests).to be_consistent
       end
 
       it "should have an externally consistent set of manifests" do
         dependencies = resolution.dependencies
         manifests = ManifestSet.new(resolution.manifests)
 
-        manifests.should be_in_compliance_with dependencies
+        expect(manifests).to be_in_compliance_with dependencies
       end
     end
 

--- a/spec/unit/lockfile_spec.rb
+++ b/spec/unit/lockfile_spec.rb
@@ -39,7 +39,7 @@ module Librarian
 
       context "just saving" do
         it "should return the lockfile text" do
-          lockfile_text.should_not be_nil
+          expect(lockfile_text).to_not be_nil
         end
       end
 
@@ -47,7 +47,7 @@ module Librarian
         let(:reloaded_resolution) { lockfile.load(lockfile_text) }
 
         it "should have the expected manifests" do
-          reloaded_resolution.manifests.count.should == resolution.manifests.count
+          expect(reloaded_resolution.manifests.count).to eq resolution.manifests.count
         end
       end
 
@@ -56,7 +56,7 @@ module Librarian
         let(:bounced_lockfile_text) { lockfile.save(bounced_resolution) }
 
         it "should return the same lockfile text after bouncing as before bouncing" do
-          bounced_lockfile_text.should == lockfile_text
+          expect(bounced_lockfile_text).to eq lockfile_text
         end
       end
     end

--- a/spec/unit/manifest/version_spec.rb
+++ b/spec/unit/manifest/version_spec.rb
@@ -5,8 +5,7 @@ describe Librarian::Manifest::Version do
   describe "#inspect" do
     subject(:version) { described_class.new("3.2.1") }
 
-    specify { version.inspect.should be ==
-      "#<Librarian::Manifest::Version 3.2.1>" }
+    specify { expect(version.inspect).to eq "#<Librarian::Manifest::Version 3.2.1>" }
   end
 
 end

--- a/spec/unit/manifest_set_spec.rb
+++ b/spec/unit/manifest_set_spec.rb
@@ -15,11 +15,11 @@ module Librarian
         let(:set) { described_class.new(array) }
 
         it "should give back the array" do
-          set.to_a.should =~ array
+          expect(set.to_a).to match_array( array )
         end
 
         it "should give back the hash" do
-          set.to_hash.should == hash
+          expect(set.to_hash).to eq hash
         end
       end
 
@@ -27,11 +27,11 @@ module Librarian
         let(:set) { described_class.new(hash) }
 
         it "should give back the array" do
-          set.to_a.should =~ array
+          expect(set.to_a).to match_array( array )
         end
 
         it "should give back the hash" do
-          set.to_hash.should == hash
+          expect(set.to_hash).to eq hash
         end
       end
     end
@@ -48,19 +48,19 @@ module Librarian
       it "should not do anything when given no names" do
         set.shallow_strip!([])
 
-        set.to_a.should =~ [jelly, butter, jam]
+        expect(set.to_a).to match_array( [jelly, butter, jam] )
       end
 
       it "should remove only the named elements" do
         set.shallow_strip!(["butter", "jam"])
 
-        set.to_a.should =~ [jelly]
+        expect(set.to_a).to match_array( [jelly] )
       end
 
       it "should allow removing all the elements" do
         set.shallow_strip!(["jelly", "butter", "jam"])
 
-        set.to_a.should =~ []
+        expect(set.to_a).to match_array( [] )
       end
     end
 
@@ -76,19 +76,19 @@ module Librarian
       it "should empty the set when given no names" do
         set.shallow_keep!([])
 
-        set.to_a.should =~ []
+        expect(set.to_a).to match_array( [] )
       end
 
       it "should keep only the named elements" do
         set.shallow_keep!(["butter", "jam"])
 
-        set.to_a.should =~ [butter, jam]
+        expect(set.to_a).to match_array( [butter, jam] )
       end
 
       it "should allow keeping all the elements" do
         set.shallow_keep!(["jelly", "butter", "jam"])
 
-        set.to_a.should =~ [jelly, butter, jam]
+        expect(set.to_a).to match_array( [jelly, butter, jam] )
       end
     end
 
@@ -117,31 +117,31 @@ module Librarian
       it "should not do anything when given no names" do
         set.deep_strip!([])
 
-        set.to_a.should =~ [a, b, c, d, e, f, g, h]
+        expect(set.to_a).to match_array( [a, b, c, d, e, f, g, h] )
       end
 
       it "should remove just the named elements if they have no dependencies" do
         set.deep_strip!(["c", "h"])
 
-        set.to_a.should =~ [a, b, d, e, f, g]
+        expect(set.to_a).to match_array( [a, b, d, e, f, g] )
       end
 
       it "should remove the named elements and all their dependencies" do
         set.deep_strip!(["b"])
 
-        set.to_a.should =~ [a, e, f, g, h]
+        expect(set.to_a).to match_array( [a, e, f, g, h] )
       end
 
       it "should remove an entire tree of dependencies" do
         set.deep_strip!(["e"])
 
-        set.to_a.should =~ [a, b, c, d]
+        expect(set.to_a).to match_array( [a, b, c, d] )
       end
 
       it "should allow removing all the elements" do
         set.deep_strip!(["a", "e"])
 
-        set.to_a.should =~ []
+        expect(set.to_a).to match_array( [] )
       end
     end
 
@@ -170,31 +170,31 @@ module Librarian
       it "should remove all the elements when given no names" do
         set.deep_keep!([])
 
-        set.to_a.should =~ []
+        expect(set.to_a).to match_array( [] )
       end
 
       it "should keep just the named elements if they have no dependencies" do
         set.deep_keep!(["c", "h"])
 
-        set.to_a.should =~ [c, h]
+        expect(set.to_a).to match_array( [c, h] )
       end
 
       it "should keep the named elements and all their dependencies" do
         set.deep_keep!(["b"])
 
-        set.to_a.should =~ [b, c, d]
+        expect(set.to_a).to match_array( [b, c, d] )
       end
 
       it "should keep an entire tree of dependencies" do
         set.deep_keep!(["e"])
 
-        set.to_a.should =~ [e, f, g, h]
+        expect(set.to_a).to match_array( [e, f, g, h] )
       end
 
       it "should allow keeping all the elements" do
         set.deep_keep!(["a", "e"])
 
-        set.to_a.should =~ [a, b, c, d, e, f, g, h]
+        expect(set.to_a).to match_array( [a, b, c, d, e, f, g, h] )
       end
     end
 

--- a/spec/unit/mock/environment_spec.rb
+++ b/spec/unit/mock/environment_spec.rb
@@ -6,19 +6,19 @@ module Librarian::Mock
     let(:env) { described_class.new }
 
     describe "#version" do
-      specify { env.version.should be == Librarian::VERSION }
+      specify { expect(env.version).to eq Librarian::VERSION }
     end
 
     describe "#adapter_module" do
-      specify { env.adapter_module.should be Librarian::Mock }
+      specify { expect(env.adapter_module).to eq Librarian::Mock }
     end
 
     describe "#adapter_name" do
-      specify { env.adapter_name.should be == "mock" }
+      specify { expect(env.adapter_name).to eq "mock" }
     end
 
     describe "#adapter_version" do
-      specify { env.adapter_version.should be == Librarian::Mock::VERSION }
+      specify { expect(env.adapter_version).to eq Librarian::Mock::VERSION }
     end
 
   end

--- a/spec/unit/resolver_spec.rb
+++ b/spec/unit/resolver_spec.rb
@@ -33,7 +33,7 @@ module Librarian
 
       let(:resolution) { resolver.resolve(spec) }
 
-      specify { resolution.should be_correct }
+      specify { expect(resolution).to be_correct }
 
     end
 
@@ -63,7 +63,7 @@ module Librarian
 
       let(:resolution) { resolver.resolve(spec) }
 
-      specify { resolution.should be_correct }
+      specify { expect(resolution).to be_correct }
 
     end
 
@@ -94,16 +94,16 @@ module Librarian
       end
 
       it "should have the expected number of sources" do
-        spec.should have(2).sources
+        expect(spec).to have(2).sources
       end
 
       let(:resolution) { resolver.resolve(spec) }
 
-      specify { resolution.should be_correct }
+      specify { expect(resolution).to be_correct }
 
       it "should have the manifest from the final source with a matching manifest" do
         manifest = resolution.manifests.find{|m| m.name == "butter"}
-        manifest.source.name.should == "source-2"
+        expect(manifest.source.name).to eq "source-2"
       end
 
     end
@@ -129,7 +129,7 @@ module Librarian
 
       let(:resolution) { resolver.resolve(spec) }
 
-      specify { resolution.should be_nil }
+      specify { expect(resolution).to be_nil }
 
     end
 
@@ -157,7 +157,7 @@ module Librarian
 
       let(:resolution) { resolver.resolve(spec) }
 
-      specify { resolution.should be_nil }
+      specify { expect(resolution).to be_nil }
 
     end
 
@@ -179,10 +179,10 @@ module Librarian
           dep 'jam'
         end
         first_resolution = resolver.resolve(first_spec)
-        first_resolution.should be_correct
+        expect(first_resolution).to be_correct
         first_manifests = first_resolution.manifests
         first_manifests_index = Hash[first_manifests.map{|m| [m.name, m]}]
-        first_manifests_index['butter'].version.to_s.should == '1.1'
+        expect(first_manifests_index['butter'].version.to_s).to eq '1.1'
 
         second_spec = env.dsl do
           src 'source-1'
@@ -191,10 +191,10 @@ module Librarian
         end
         locked_manifests = ManifestSet.deep_strip(first_manifests, ['butter'])
         second_resolution =resolver.resolve(second_spec, locked_manifests)
-        second_resolution.should be_correct
+        expect(second_resolution).to be_correct
         second_manifests = second_resolution.manifests
         second_manifests_index = Hash[second_manifests.map{|m| [m.name, m]}]
-        second_manifests_index['butter'].version.to_s.should == '1.0'
+        expect(second_manifests_index['butter'].version.to_s).to eq '1.0'
       end
 
     end
@@ -215,22 +215,22 @@ module Librarian
           dep 'butter'
         end
         lock = resolver.resolve(spec)
-        lock.should be_correct
+        expect(lock).to be_correct
 
         spec = env.dsl do
           src 'source-1'
           dep 'butter', :src => 'source-2'
         end
         changes = SpecChangeSet.new(env, spec, lock)
-        changes.should_not be_same
+        expect(changes).to_not be_same
         manifests = ManifestSet.new(changes.analyze).to_hash
-        manifests.should_not have_key('butter')
+        expect(manifests).to_not have_key('butter')
         lock = resolver.resolve(spec, changes.analyze)
-        lock.should be_correct
-        lock.manifests.map{|m| m.name}.should include('butter')
+        expect(lock).to be_correct
+        expect(lock.manifests.map{|m| m.name}).to include('butter')
         manifest = lock.manifests.find{|m| m.name == 'butter'}
-        manifest.should_not be_nil
-        manifest.source.name.should == 'source-2'
+        expect(manifest).to_not be_nil
+        expect(manifest.source.name).to eq 'source-2'
       end
 
     end
@@ -247,9 +247,9 @@ module Librarian
       it "loads the specfile with the __FILE__" do
         write! specfile_path, "src __FILE__"
         spec = env.dsl(specfile_path)
-        spec.sources.should have(1).item
+        expect(spec.sources).to have(1).item
         source = spec.sources.first
-        source.name.should == specfile_path.to_s
+        expect(source.name).to eq specfile_path.to_s
       end
 
     end

--- a/spec/unit/spec_change_set_spec.rb
+++ b/spec/unit/spec_change_set_spec.rb
@@ -23,18 +23,18 @@ module Librarian
           dep 'jam'
         end
         lock = resolver.resolve(spec)
-        lock.should be_correct
+        expect(lock).to be_correct
 
         spec = env.dsl do
           src 'source-1'
           dep 'jam'
         end
         changes = described_class.new(env, spec, lock)
-        changes.should_not be_same
+        expect(changes).to_not be_same
 
         manifests = ManifestSet.new(changes.analyze).to_hash
-        manifests.should have_key('jam')
-        manifests.should_not have_key('butter')
+        expect(manifests).to have_key('jam')
+        expect(manifests).to_not have_key('butter')
       end
 
     end
@@ -53,7 +53,7 @@ module Librarian
           dep 'jam'
         end
         lock = resolver.resolve(spec)
-        lock.should be_correct
+        expect(lock).to be_correct
 
         spec = env.dsl do
           src 'source-1'
@@ -61,10 +61,10 @@ module Librarian
           dep 'jam'
         end
         changes = described_class.new(env, spec, lock)
-        changes.should_not be_same
+        expect(changes).to_not be_same
         manifests = ManifestSet.new(changes.analyze).to_hash
-        manifests.should have_key('jam')
-        manifests.should_not have_key('butter')
+        expect(manifests).to have_key('jam')
+        expect(manifests).to_not have_key('butter')
       end
 
     end
@@ -87,7 +87,7 @@ module Librarian
             dep 'jam', '= 1.1'
           end
           lock = resolver.resolve(spec)
-          lock.should be_correct
+          expect(lock).to be_correct
 
           spec = env.dsl do
             src 'source-1'
@@ -95,10 +95,10 @@ module Librarian
             dep 'jam', '>= 1.0'
           end
           changes = described_class.new(env, spec, lock)
-          changes.should_not be_same
+          expect(changes).to_not be_same
           manifests = ManifestSet.new(changes.analyze).to_hash
-          manifests.should have_key('butter')
-          manifests.should have_key('jam')
+          expect(manifests).to have_key('butter')
+          expect(manifests).to have_key('jam')
         end
 
       end
@@ -119,7 +119,7 @@ module Librarian
             dep 'jam', '= 1.0'
           end
           lock = resolver.resolve(spec)
-          lock.should be_correct
+          expect(lock).to be_correct
 
           spec = env.dsl do
             src 'source-1'
@@ -127,10 +127,10 @@ module Librarian
             dep 'jam', '>= 1.1'
           end
           changes = described_class.new(env, spec, lock)
-          changes.should_not be_same
+          expect(changes).to_not be_same
           manifests = ManifestSet.new(changes.analyze).to_hash
-          manifests.should have_key('butter')
-          manifests.should_not have_key('jam')
+          expect(manifests).to have_key('butter')
+          expect(manifests).to_not have_key('jam')
         end
 
       end
@@ -152,16 +152,16 @@ module Librarian
           dep 'butter'
         end
         lock = resolver.resolve(spec)
-        lock.should be_correct
+        expect(lock).to be_correct
 
         spec = env.dsl do
           src 'source-1'
           dep 'butter', :src => 'source-2'
         end
         changes = described_class.new(env, spec, lock)
-        changes.should_not be_same
+        expect(changes).to_not be_same
         manifests = ManifestSet.new(changes.analyze).to_hash
-        manifests.should_not have_key('butter')
+        expect(manifests).to_not have_key('butter')
       end
     end
 


### PR DESCRIPTION
Hi, I'd like to offer this suggestion for changes to the RSpec syntax to use expect.  I noticed that some of the more recent specs in this gem have started to use it already (e.g. unit/dependency_spec.rb or unit/environment_spec.rb), so this change would make the usage consistent throughout the test suite. More than just a style change, it has turned turned out that using 'expect' over 'should' is a recommended practice because of dealing with delegate/proxy objects as detailed in http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax.
As detailed in the blog post "In the future, we plan to change the defaults so that only expect is available unless you explicitly enable should. We may do this as soon as RSpec 3.0, but we want to give users plenty of time to get acquianted with it."  I've also noticed that many of the major github gems have already made the move.  It also helps the spec and the error reporting readability be more english like.
I changed the pattern matchers from =~ to match() as required for this change and while at it I also took the opportunity to change the '==' operator to 'eq' as recommended in the post.
All tests pass.
