### PR TITLE
Fix JRuby exception in posix run! method

### DIFF
--- a/lib/librarian/posix.rb
+++ b/lib/librarian/posix.rb
@@ -65,7 +65,7 @@ module Librarian
           ensure
             ENV.update old_env
           end
-          $?.success? or CommandFailure.raise! command, $?, err
+          ($?.value == 0) or CommandFailure.raise! command, $?.value, err
           out
         end
 


### PR DESCRIPTION
```
NoMethodError:
undefined method `success?' for #<Process::WaitThread:0xd5c0e84 dead>
```

WaitThread does not have a success? method, but it does have a value
property which can be checked instead.

Build succeeds with [jruby-d19](https://travis-ci.org/justenwalker/librarian/jobs/16218343)
