### PR TITLE
Ensure equality comparisons work for Source objects

### DIFF
--- a/lib/librarian/dependency.rb
+++ b/lib/librarian/dependency.rb
@@ -22,6 +22,12 @@ module Librarian
         to_gem_requirement == other.to_gem_requirement
       end
 
+      alias :eql? :==
+
+      def hash
+        self.to_s.hash
+      end
+
       def to_s
         to_gem_requirement.to_s
       end

--- a/lib/librarian/mock/source/mock.rb
+++ b/lib/librarian/mock/source/mock.rb
@@ -30,6 +30,12 @@ module Librarian
           self.name   == other.name
         end
 
+        alias :eql? :==
+
+        def hash
+          self.to_s.hash
+        end
+
         def to_spec_args
           [name, {}]
         end

--- a/lib/librarian/source/git.rb
+++ b/lib/librarian/source/git.rb
@@ -52,6 +52,12 @@ module Librarian
         (self.sha.nil? || other.sha.nil? || self.sha == other.sha)
       end
 
+      alias :eql? :==
+
+      def hash
+        self.to_s.hash
+      end
+
       def to_spec_args
         options = {}
         options.merge!(:ref => ref) if ref != DEFAULTS[:ref]

--- a/lib/librarian/source/path.rb
+++ b/lib/librarian/source/path.rb
@@ -29,6 +29,12 @@ module Librarian
         self.path   == other.path
       end
 
+      alias :eql? :==
+
+      def hash
+        self.to_s.hash
+      end
+
       def to_spec_args
         [path.to_s, {}]
       end


### PR DESCRIPTION
Implement functions eql? and hash as they are required for
proper evaluation of functions like uniq and to add them
to a Set without duplicates
