### PR TITLE
Fail gracefully when updating a module that does not exist

### DIFF
--- a/lib/librarian/manifest_set.rb
+++ b/lib/librarian/manifest_set.rb
@@ -137,6 +137,7 @@ module Librarian
         next if deps.include?(name)
 
         deps << name
+        raise(Error, "Unable to find module #{name}") if index[name].nil?
         names.concat index[name].dependencies.map(&:name)
       end
       deps.to_a


### PR DESCRIPTION
Instead of causing a nil error later on
