### PR TITLE
Manage current directory of process when running a specfile

### DIFF
--- a/lib/librarian/dsl/receiver.rb
+++ b/lib/librarian/dsl/receiver.rb
@@ -27,7 +27,9 @@ module Librarian
 
         case specfile
         when Pathname
-          instance_eval(File.read(specfile), specfile.to_s, 1)
+          Dir.chdir(File.dirname(specfile.to_s)) do
+            instance_eval(File.read(specfile), specfile.to_s, 1)
+          end
         when String
           instance_eval(specfile)
         when Proc


### PR DESCRIPTION
When you have a nested dependency containing its own specfile, the file is eval'd using the process's current directory instead of the directory of the specfile.  This causes file reads which are done relative to the specfile to run in the wrong directory.

Specifically: a librarian-puppet project having a git dependency which also contains a Puppetfile in its root. This Puppetfile uses the `modulefile` dsl, causing a `File.read('Modulefile')` in the current directory.  This read needs to happen in the appropriate subfolder in `.tmp/librarian/cache`.
