### PR TITLE
Avoid removal of install_path directory

### DIFF
--- a/lib/librarian/action/install.rb
+++ b/lib/librarian/action/install.rb
@@ -40,7 +40,9 @@ module Librarian
       end
 
       def create_install_path
-        install_path.rmtree if install_path.exist?
+        if install_path.exist?
+          FileUtils.rm_r install_path.children
+        end
         install_path.mkpath
       end
 


### PR DESCRIPTION
This is a pull request for #151.
Removing the install_dir during each "librarian-chef install" breaks the shared folder of vagrant for at least the lxc and fusion provider.
