### PR TITLE
getlogin returns nil when it's called from a non-login shell

### DIFF
--- a/lib/librarian/environment.rb
+++ b/lib/librarian/environment.rb
@@ -203,7 +203,7 @@ module Librarian
     end
 
     def default_home
-      File.expand_path(ENV["HOME"] || Etc.getpwnam(Etc.getlogin).dir)
+      File.expand_path(ENV["HOME"] || Etc.getpwnam(Etc.getpwuid.name).dir)
     end
 
     def no_proxy_list


### PR DESCRIPTION
which will cause an 

'/lib/ruby/gems/2.1.0/gems/librarian-0.1.2/lib/librarian/environment.rb:206:in `getpwnam': no implicit conversion of nil into String (TypeError)'

ruby-doc recommend using getpwuid in case of getlogin failure
