### PR TITLE
Pin rspec to 2.x until test suite is updated to rspec 3

### DIFF
--- a/librarian.gemspec
+++ b/librarian.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "highline"
 
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "rspec", "~> 2.99"
   gem.add_development_dependency "json"
   gem.add_development_dependency "fakefs", "~> 0.4.2"
 end


### PR DESCRIPTION
The test suite fails under rspec 3, so I updated the gemspec to indicate a requirement on rspec 2.
