### PR TITLE
Prioritize the resolver queue to favor early conflict resolution

### DIFF
--- a/lib/librarian/dependency.rb
+++ b/lib/librarian/dependency.rb
@@ -18,6 +18,10 @@ module Librarian
         to_gem_requirement.satisfied_by?(version.to_gem_version)
       end
 
+      def specific?
+        to_gem_requirement.specific?
+      end
+
       def ==(other)
         to_gem_requirement == other.to_gem_requirement
       end

--- a/lib/librarian/resolver/implementation.rb
+++ b/lib/librarian/resolver/implementation.rb
@@ -26,7 +26,28 @@ module Librarian
         def initialize(manifests, dependencies, queue)
           self.manifests = manifests
           self.dependencies = dependencies # resolved
-          self.queue = queue # scheduled
+          self.queue = sort_queue(queue) # scheduled
+        end
+
+        private
+        def sort_queue(queue)
+          # sort the queue as follows:
+          # 0. any dependency that matches something already in the manifest
+          # 1. any dependency that is specific, i.e. not necessarily the latest version
+          # 2. other dependencies
+          buckets = [[], [], []]
+
+          queue.each { |d|
+            if manifests[d.name]
+              buckets[0]
+            elsif d.requirement.specific?
+              buckets[1]
+            else
+              buckets[2]
+            end << d
+          }
+
+          buckets.flatten
         end
       end
 


### PR DESCRIPTION
This fixes #175. `librarian-chef install --verbose` output for that `Cheffile` is much more tame ([gist](https://gist.github.com/willglynn/98276399a50576d087a1)) and, as a bonus, it actually finishes.
