### PR TITLE
GIT_DIR should point to the absolute git directory

### DIFF
--- a/lib/librarian/source/git/repository.rb
+++ b/lib/librarian/source/git/repository.rb
@@ -128,7 +128,7 @@ module Librarian
 
           silent = options.delete(:silent)
           pwd = chdir || Dir.pwd
-          git_dir = File.join(path, ".git") if path
+          git_dir = File.join(path.realpath, ".git") if path
           env = {"GIT_DIR" => git_dir}
 
           command = [bin]


### PR DESCRIPTION
Hello,

When options `chdir` is passed, and `chdir` is different than PWD, `GIT_DIR` is pointing to a relative url that doesn't exist.

By forcing the GIT_DIR to be absolute we avoid this issue.

Cheers
